### PR TITLE
Enhance output with prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 var tapLog = function (prefix) {
   return function (object) {
-    console.log(prefix ? prefix + ': ' + object : object)
+    if (prefix) {
+      console.log(prefix + ': ', object)
+    } else {
+      console.log(object)
+    }
     return object
   }
 }


### PR DESCRIPTION
Concatenating the object to the prefix causes `.toString()` to be called on the object, which often leads to an output like `[object Object]`. Adding it as an additional parameter often leads to a more helpful output.